### PR TITLE
Updated supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
 script:
   - python runtests.py
 env:
-  - DJANGO="Django==1.4.22"
   - DJANGO="Django==1.5.12"
   - DJANGO="Django==1.6.11"
   - DJANGO="Django==1.7.11"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 + Currently requires Python 2.7.
-+ Supports Django 1.4+ (including 1.7.x).
++ Supports Django 1.5+ (including 1.8.x).
 + Supports AngularJS 1.2+ (including 1.3.x).
 + ~~Local installs of Node.js and Karma for testing.~~
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 + Currently requires Python 2.7.
-+ Supports Django 1.5+ (including 1.8.x).
++ Supports Django >= 1.5, < 1.9
 + Supports AngularJS 1.2+ (including 1.3.x).
 + ~~Local installs of Node.js and Karma for testing.~~
 


### PR DESCRIPTION
Django 1.4 has been unsupported since https://github.com/appliedsec/djangular/commit/e409514fd30d00e66628dbdb41357dcbb0545a00 so remove it from supported versions. Add 1.8.