### PR TITLE
Django 1.9 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -25,7 +25,6 @@ exclude_lines =
 omit =
     *tests*
     *migrations*
-    *urls*
     *site-packages*
     *src*
     *settings*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ env:
   - DJANGO="Django==1.6.11"
   - DJANGO="Django==1.7.11"
   - DJANGO="Django==1.8.12"
+  - DJANGO="Django==1.9.5"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 + Currently requires Python 2.7.
-+ Supports Django >= 1.5, < 1.9
++ Supports Django >= 1.5, <= 1.9
 + Supports AngularJS 1.2+ (including 1.3.x).
 + ~~Local installs of Node.js and Karma for testing.~~
 

--- a/djangular/tests/__init__.py
+++ b/djangular/tests/__init__.py
@@ -7,3 +7,4 @@ if django.VERSION < (1, 6):
     from djangular.tests.test_storage import *
     from djangular.tests.test_utils import *
     from djangular.tests.test_commands import *
+    from djangular.tests.test_urls import *

--- a/djangular/tests/test_urls.py
+++ b/djangular/tests/test_urls.py
@@ -1,0 +1,8 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+
+class UrlsTests(TestCase):
+    def test_urls_import(self):
+        """Smoke test to make sure urls imports are valid."""
+        self.assertEqual('/app.js', reverse('djangular-module'))

--- a/runtests.py
+++ b/runtests.py
@@ -29,6 +29,7 @@ if not settings.configured:
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',  
         ],
+        ROOT_URLCONF='djangular.urls'
     )
 
 


### PR DESCRIPTION
Seems we were already compatible with Django 1.9. Added this to the docs and added some test coverage to the urls file.